### PR TITLE
[PR] Clean reset password characters

### DIFF
--- a/includes/format.php
+++ b/includes/format.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace WSU\SendRestEmail\Format;
+
+add_filter( 'retrieve_password_message', 'WSU\SendRestEmail\Format\password_reset_message', 10 );
+
+/**
+ * Filter the password reset message so that the URL will pass wp_kses_post
+ * in the REST request handler.
+ *
+ * @since 0.0.2
+ *
+ * @param string $message
+ *
+ * @return string
+ */
+function password_reset_message( $message ) {
+	$message = str_replace( '<http', ' http', $message );
+	$message = str_replace( ">\r\n", " \r\n", $message );
+
+	return $message;
+}

--- a/includes/wp-new-user-notification.php
+++ b/includes/wp-new-user-notification.php
@@ -1,0 +1,80 @@
+<?php
+
+if ( !function_exists('wp_new_user_notification') ) :
+	/**
+	 * Email login credentials to a newly-registered user.
+	 *
+	 * A new user registration notification is also sent to admin email.
+	 *
+	 * @since 2.0.0
+	 * @since 4.3.0 The `$plaintext_pass` parameter was changed to `$notify`.
+	 * @since 4.3.1 The `$plaintext_pass` parameter was deprecated. `$notify` added as a third parameter.
+	 * @since 4.6.0 The `$notify` parameter accepts 'user' for sending notification only to the user created.
+	 *
+	 * @global wpdb         $wpdb      WordPress database object for queries.
+	 * @global PasswordHash $wp_hasher Portable PHP password hashing framework instance.
+	 *
+	 * @param int    $user_id    User ID.
+	 * @param null   $deprecated Not used (argument deprecated).
+	 * @param string $notify     Optional. Type of notification that should happen. Accepts 'admin' or an empty
+	 *                           string (admin only), 'user', or 'both' (admin and user). Default empty.
+	 */
+	function wp_new_user_notification( $user_id, $deprecated = null, $notify = '' ) {
+		if ( $deprecated !== null ) {
+			_deprecated_argument( __FUNCTION__, '4.3.1' );
+		}
+
+		global $wpdb, $wp_hasher;
+		$user = get_userdata( $user_id );
+
+		// The blogname option is escaped with esc_html on the way into the database in sanitize_option
+		// we want to reverse this for the plain text arena of emails.
+		$blogname = wp_specialchars_decode(get_option('blogname'), ENT_QUOTES);
+
+		if ( 'user' !== $notify ) {
+			$switched_locale = switch_to_locale( get_locale() );
+			$message  = sprintf( __( 'New user registration on your site %s:' ), $blogname ) . "\r\n\r\n";
+			$message .= sprintf( __( 'Username: %s' ), $user->user_login ) . "\r\n\r\n";
+			$message .= sprintf( __( 'Email: %s' ), $user->user_email ) . "\r\n";
+
+			@wp_mail( get_option( 'admin_email' ), sprintf( __( '[%s] New User Registration' ), $blogname ), $message );
+
+			if ( $switched_locale ) {
+				restore_previous_locale();
+			}
+		}
+
+		// `$deprecated was pre-4.3 `$plaintext_pass`. An empty `$plaintext_pass` didn't sent a user notification.
+		if ( 'admin' === $notify || ( empty( $deprecated ) && empty( $notify ) ) ) {
+			return;
+		}
+
+		// Generate something random for a password reset key.
+		$key = wp_generate_password( 20, false );
+
+		/** This action is documented in wp-login.php */
+		do_action( 'retrieve_password_key', $user->user_login, $key );
+
+		// Now insert the key, hashed, into the DB.
+		if ( empty( $wp_hasher ) ) {
+			require_once ABSPATH . WPINC . '/class-phpass.php';
+			$wp_hasher = new PasswordHash( 8, true );
+		}
+		$hashed = time() . ':' . $wp_hasher->HashPassword( $key );
+		$wpdb->update( $wpdb->users, array( 'user_activation_key' => $hashed ), array( 'user_login' => $user->user_login ) );
+
+		$switched_locale = switch_to_locale( get_user_locale( $user ) );
+
+		$message = sprintf(__('Username: %s'), $user->user_login) . "\r\n\r\n";
+		$message .= __('To set your password, visit the following address:') . "\r\n\r\n";
+		$message .= '<' . network_site_url("wp-login.php?action=rp&key=$key&login=" . rawurlencode($user->user_login), 'login') . ">\r\n\r\n";
+
+		$message .= wp_login_url() . "\r\n";
+
+		wp_mail($user->user_email, sprintf(__('[%s] Your username and password info'), $blogname), $message);
+
+		if ( $switched_locale ) {
+			restore_previous_locale();
+		}
+	}
+endif;

--- a/includes/wp-new-user-notification.php
+++ b/includes/wp-new-user-notification.php
@@ -1,26 +1,26 @@
 <?php
 
-if ( !function_exists('wp_new_user_notification') ) :
+if ( ! function_exists( 'wp_new_user_notification' ) ) :
 	/**
-	 * Email login credentials to a newly-registered user.
-	 *
-	 * A new user registration notification is also sent to admin email.
-	 *
-	 * @since 2.0.0
-	 * @since 4.3.0 The `$plaintext_pass` parameter was changed to `$notify`.
-	 * @since 4.3.1 The `$plaintext_pass` parameter was deprecated. `$notify` added as a third parameter.
-	 * @since 4.6.0 The `$notify` parameter accepts 'user' for sending notification only to the user created.
-	 *
-	 * @global wpdb         $wpdb      WordPress database object for queries.
-	 * @global PasswordHash $wp_hasher Portable PHP password hashing framework instance.
-	 *
-	 * @param int    $user_id    User ID.
-	 * @param null   $deprecated Not used (argument deprecated).
-	 * @param string $notify     Optional. Type of notification that should happen. Accepts 'admin' or an empty
-	 *                           string (admin only), 'user', or 'both' (admin and user). Default empty.
-	 */
+ * Email login credentials to a newly-registered user.
+ *
+ * A new user registration notification is also sent to admin email.
+ *
+ * @since 2.0.0
+ * @since 4.3.0 The `$plaintext_pass` parameter was changed to `$notify`.
+ * @since 4.3.1 The `$plaintext_pass` parameter was deprecated. `$notify` added as a third parameter.
+ * @since 4.6.0 The `$notify` parameter accepts 'user' for sending notification only to the user created.
+ *
+ * @global wpdb         $wpdb      WordPress database object for queries.
+ * @global PasswordHash $wp_hasher Portable PHP password hashing framework instance.
+ *
+ * @param int    $user_id    User ID.
+ * @param null   $deprecated Not used (argument deprecated).
+ * @param string $notify     Optional. Type of notification that should happen. Accepts 'admin' or an empty
+ *                           string (admin only), 'user', or 'both' (admin and user). Default empty.
+ */
 	function wp_new_user_notification( $user_id, $deprecated = null, $notify = '' ) {
-		if ( $deprecated !== null ) {
+		if ( null !== $deprecated ) {
 			_deprecated_argument( __FUNCTION__, '4.3.1' );
 		}
 
@@ -29,7 +29,7 @@ if ( !function_exists('wp_new_user_notification') ) :
 
 		// The blogname option is escaped with esc_html on the way into the database in sanitize_option
 		// we want to reverse this for the plain text arena of emails.
-		$blogname = wp_specialchars_decode(get_option('blogname'), ENT_QUOTES);
+		$blogname = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
 
 		if ( 'user' !== $notify ) {
 			$switched_locale = switch_to_locale( get_locale() );
@@ -37,7 +37,7 @@ if ( !function_exists('wp_new_user_notification') ) :
 			$message .= sprintf( __( 'Username: %s' ), $user->user_login ) . "\r\n\r\n";
 			$message .= sprintf( __( 'Email: %s' ), $user->user_email ) . "\r\n";
 
-			@wp_mail( get_option( 'admin_email' ), sprintf( __( '[%s] New User Registration' ), $blogname ), $message );
+			@wp_mail( get_option( 'admin_email' ), sprintf( __( '[%s] New User Registration' ), $blogname ), $message ); // @codingStandardsIgnoreLine
 
 			if ( $switched_locale ) {
 				restore_previous_locale();
@@ -52,26 +52,32 @@ if ( !function_exists('wp_new_user_notification') ) :
 		// Generate something random for a password reset key.
 		$key = wp_generate_password( 20, false );
 
-		/** This action is documented in wp-login.php */
+		/**
+* This action is documented in wp-login.php
+*/
 		do_action( 'retrieve_password_key', $user->user_login, $key );
 
 		// Now insert the key, hashed, into the DB.
 		if ( empty( $wp_hasher ) ) {
-			require_once ABSPATH . WPINC . '/class-phpass.php';
-			$wp_hasher = new PasswordHash( 8, true );
+			include_once ABSPATH . WPINC . '/class-phpass.php';
+			$wp_hasher = new PasswordHash( 8, true ); // @codingStandardsIgnoreLine
 		}
 		$hashed = time() . ':' . $wp_hasher->HashPassword( $key );
-		$wpdb->update( $wpdb->users, array( 'user_activation_key' => $hashed ), array( 'user_login' => $user->user_login ) );
+		$wpdb->update( $wpdb->users, array(
+			'user_activation_key' => $hashed,
+			), array(
+			'user_login' => $user->user_login,
+		) );
 
-		$switched_locale = switch_to_locale( get_user_locale( $user ) );
+			$switched_locale = switch_to_locale( get_user_locale( $user ) );
 
-		$message = sprintf(__('Username: %s'), $user->user_login) . "\r\n\r\n";
-		$message .= __('To set your password, visit the following address:') . "\r\n\r\n";
-		$message .= '<' . network_site_url("wp-login.php?action=rp&key=$key&login=" . rawurlencode($user->user_login), 'login') . ">\r\n\r\n";
+			$message = sprintf( __( 'Username: %s' ), $user->user_login ) . "\r\n\r\n";
+			$message .= __( 'To set your password, visit the following address:' ) . "\r\n\r\n";
+			$message .= '<' . network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user->user_login ), 'login' ) . ">\r\n\r\n";
 
-		$message .= wp_login_url() . "\r\n";
+			$message .= wp_login_url() . "\r\n";
 
-		wp_mail($user->user_email, sprintf(__('[%s] Your username and password info'), $blogname), $message);
+			wp_mail( $user->user_email, sprintf( __( '[%s] Your username and password info' ), $blogname ), $message );
 
 		if ( $switched_locale ) {
 			restore_previous_locale();

--- a/includes/wp-new-user-notification.php
+++ b/includes/wp-new-user-notification.php
@@ -2,23 +2,23 @@
 
 if ( ! function_exists( 'wp_new_user_notification' ) ) :
 	/**
- * Email login credentials to a newly-registered user.
- *
- * A new user registration notification is also sent to admin email.
- *
- * @since 2.0.0
- * @since 4.3.0 The `$plaintext_pass` parameter was changed to `$notify`.
- * @since 4.3.1 The `$plaintext_pass` parameter was deprecated. `$notify` added as a third parameter.
- * @since 4.6.0 The `$notify` parameter accepts 'user' for sending notification only to the user created.
- *
- * @global wpdb         $wpdb      WordPress database object for queries.
- * @global PasswordHash $wp_hasher Portable PHP password hashing framework instance.
- *
- * @param int    $user_id    User ID.
- * @param null   $deprecated Not used (argument deprecated).
- * @param string $notify     Optional. Type of notification that should happen. Accepts 'admin' or an empty
- *                           string (admin only), 'user', or 'both' (admin and user). Default empty.
- */
+	 * Email login credentials to a newly-registered user.
+	 *
+	 * A new user registration notification is also sent to admin email.
+	 *
+	 * @since 2.0.0
+	 * @since 4.3.0 The `$plaintext_pass` parameter was changed to `$notify`.
+	 * @since 4.3.1 The `$plaintext_pass` parameter was deprecated. `$notify` added as a third parameter.
+	 * @since 4.6.0 The `$notify` parameter accepts 'user' for sending notification only to the user created.
+	 *
+	 * @global wpdb         $wpdb      WordPress database object for queries.
+	 * @global PasswordHash $wp_hasher Portable PHP password hashing framework instance.
+	 *
+	 * @param int    $user_id    User ID.
+	 * @param null   $deprecated Not used (argument deprecated).
+	 * @param string $notify     Optional. Type of notification that should happen. Accepts 'admin' or an empty
+	 *                           string (admin only), 'user', or 'both' (admin and user). Default empty.
+	 */
 	function wp_new_user_notification( $user_id, $deprecated = null, $notify = '' ) {
 		if ( null !== $deprecated ) {
 			_deprecated_argument( __FUNCTION__, '4.3.1' );
@@ -52,9 +52,7 @@ if ( ! function_exists( 'wp_new_user_notification' ) ) :
 		// Generate something random for a password reset key.
 		$key = wp_generate_password( 20, false );
 
-		/**
-* This action is documented in wp-login.php
-*/
+		// This action is documented in wp-login.php.
 		do_action( 'retrieve_password_key', $user->user_login, $key );
 
 		// Now insert the key, hashed, into the DB.
@@ -69,15 +67,15 @@ if ( ! function_exists( 'wp_new_user_notification' ) ) :
 			'user_login' => $user->user_login,
 		) );
 
-			$switched_locale = switch_to_locale( get_user_locale( $user ) );
+		$switched_locale = switch_to_locale( get_user_locale( $user ) );
 
-			$message = sprintf( __( 'Username: %s' ), $user->user_login ) . "\r\n\r\n";
-			$message .= __( 'To set your password, visit the following address:' ) . "\r\n\r\n";
-			$message .= ' ' . network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user->user_login ), 'login' ) . " \r\n\r\n";
+		$message = sprintf( __( 'Username: %s' ), $user->user_login ) . "\r\n\r\n";
+		$message .= __( 'To set your password, visit the following address:' ) . "\r\n\r\n";
+		$message .= ' ' . network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user->user_login ), 'login' ) . " \r\n\r\n";
 
-			$message .= wp_login_url() . "\r\n";
+		$message .= wp_login_url() . "\r\n";
 
-			wp_mail( $user->user_email, sprintf( __( '[%s] Your username and password info' ), $blogname ), $message );
+		wp_mail( $user->user_email, sprintf( __( '[%s] Your username and password info' ), $blogname ), $message );
 
 		if ( $switched_locale ) {
 			restore_previous_locale();

--- a/includes/wp-new-user-notification.php
+++ b/includes/wp-new-user-notification.php
@@ -73,7 +73,7 @@ if ( ! function_exists( 'wp_new_user_notification' ) ) :
 
 			$message = sprintf( __( 'Username: %s' ), $user->user_login ) . "\r\n\r\n";
 			$message .= __( 'To set your password, visit the following address:' ) . "\r\n\r\n";
-			$message .= '<' . network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user->user_login ), 'login' ) . ">\r\n\r\n";
+			$message .= ' ' . network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user->user_login ), 'login' ) . " \r\n\r\n";
 
 			$message .= wp_login_url() . "\r\n";
 

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -1,8 +1,30 @@
 <?xml version="1.0"?>
 <ruleset name="WSUWP Plugins">
+
+    <!-- Config flags for PHPCS
+		 s flag: Show sniff codes in all reports.
+		 v flag: Print verbose output.
+	-->
+    <arg value="sv"/>
+
+    <!-- Check only PHP files -->
+    <arg name="extensions" value="php"/>
+
+    <!-- Check all files in this directory and the directories below it. -->
+    <file>.</file>
+
     <description>Sniffs for PHP coding standards used by WSUWP Plugins</description>
 
     <rule ref="WordPress-Extra">
         <exclude name="WordPress.NamingConventions.ValidFunctionName" />
+        <exclude name="WordPress.Files.FileName" />
+        <exclude name="Squiz.PHP.EmbeddedPhp.NoSemicolon" />
+        <exclude name="Squiz.PHP.EmbeddedPhp.ContentBeforeEnd" />
+        <exclude name="Squiz.PHP.EmbeddedPhp.ContentBeforeOpen" />
+        <exclude name="Squiz.PHP.EmbeddedPhp.ContentAfterOpen" />
+        <exclude name="Squiz.PHP.EmbeddedPhp.ContentAfterEnd" />
+        <exclude name="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace" />
+
+        <exclude name="WordPress.WP.I18n.MissingTranslatorsComment" />
     </rule>
 </ruleset>

--- a/plugin.php
+++ b/plugin.php
@@ -24,5 +24,6 @@ add_action( 'plugins_loaded', 'WSU\SendRestEmail\bootstrap' );
  * @since 0.0.1
  */
 function bootstrap() {
+	include_once __DIR__ . '/includes/format.php';
 	include_once __DIR__ . '/includes/request.php';
 }

--- a/plugin.php
+++ b/plugin.php
@@ -15,7 +15,9 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
+// Pluggable functions.
 include_once __DIR__ . '/includes/wp-mail.php';
+include_once __DIR__ . '/includes/wp-new-user-notification.php';
 
 add_action( 'plugins_loaded', 'WSU\SendRestEmail\bootstrap' );
 /**


### PR DESCRIPTION
The URL sent in the password reset and new user notification emails is formatted (by default) as `<http://url.url?url=url>`, which makes it look like possible malicious HTML when parsed by `wp_kses_post()` on the other end through https://github.com/washingtonstateuniversity/WSUWP-Plugin-REST-Email-Proxy

This filters the password reset email to remove `<` and `>`. It also includes a copy of the pluggable function `wp_new_user_notification()` from WordPress core that removes these characters. In WordPress 4.9, we'll be able to remove this code and use the filters introduced here instead - https://core.trac.wordpress.org/changeset/41213